### PR TITLE
Minor documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ stgit` or `zypper in stgit`. Alternatively, you can clone the
 [stgit repo](https://github.com/ctmarinas/stgit.git) and install it manually if
 you want to run the latest and greatest version.
 
-Next, run the following commands.
+Next, run the `patch` program from the repository root directory (sibling to
+this file).
 
 ```
-git clone git@github.com:BeStateless/gobgp.git
-cd gobgp
 ./patch
 ```
 
@@ -30,7 +29,7 @@ stgit set up on the tip of the patch set.
 To make a new patch simply use `stg new patch-name.patch`, edit the files you
 want to include in the patch, use `stg refresh` to incorporate those changes
 into the patch, and finally use `stg export -d ../patches` from the inner
-`RAMCloud` directory to export the new patch. Modifying an existing patch,
+`gobgp` directory to export the new patch. Modifying an existing patch,
 reordering patches, rebasing onto newer upstream changes, and other operations
 are explained in the
 [stgit tutorial](http://procode.org/stgit/doc/tutorial.html).


### PR DESCRIPTION
* You now just run `./patch`, so changes the documentation to reflect this
* Exporting patches referred to RAMCloud instead of GoBGP
