### PR TITLE
NF-596 - Allow link GoBGP containers to run Zebra.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM statelesstestregistry.azurecr.io/stateless/base:8 as build
+FROM statelesstestregistry.azurecr.io/stateless/base:9 as build
 
 # Install build dependencies.
 RUN apt-get update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,14 +3,79 @@ FROM statelesstestregistry.azurecr.io/stateless/base:9 as build
 # Install build dependencies.
 RUN apt-get update \
  && apt-get install --yes --no-install-recommends \
+      autoconf \
+      automake \
       build-essential \
       ca-certificates \
       golang \
+      libreadline-dev \
+      texinfo \
+      pkg-config \
+      bison \
+      flex \
+      libc-ares-dev \
+      python3-dev \
+      python3-pytest \
+      python3-sphinx \
+      libsnmp-dev \
+      libcap-dev \
+      libjson-c-dev \
+      libyang-dev \
+      libtool \
       procps \
       socat \
       stgit \
+      supervisor \
  && rm -rf /var/lib/apt/lists/*
 
+
+# Install FRRouting. This simply follows the instructions at
+# http://docs.frrouting.org/projects/dev-guide/en/latest/building-frr-for-debian9.html
+#
+# The version that comes with Debian Buster is quite old. We just need this for Zebra.
+RUN addgroup --system --gid 92 frr \
+ && addgroup --system --gid 85 frrvty \
+ && adduser --system --ingroup frr --home /var/opt/frr --gecos "FRR Suite" --shell /bin/false frr \
+ && usermod -a -G frrvty frr \
+ && git clone https://github.com/frrouting/frr.git frr \
+ && cd frr \
+ && git checkout frr-7.1 \
+ && ./bootstrap.sh \
+ && ./configure \
+      --enable-exampledir=/usr/share/doc/frr/examples/ \
+      --localstatedir=/var/opt/frr \
+      --sbindir=/usr/lib/frr \
+      --sysconfdir=/etc/frr \
+      --enable-multipath=64 \
+      --enable-user=frr \
+      --enable-group=frr \
+      --enable-vty-group=frrvty \
+      --enable-configfile-mask=0640 \
+      --enable-logfile-mask=0640 \
+      --enable-fpm \
+      --with-pkg-git-version \
+      --with-pkg-extra-version=-stateless \
+ && make -j$(( $(nproc) + 1 )) \
+ && make install \
+ && install -m 755 -o frr -g frr -d /var/log/frr \
+ && install -m 755 -o frr -g frr -d /var/opt/frr \
+ && install -m 775 -o frr -g frrvty -d /etc/frr \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/zebra.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/bgpd.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/ospfd.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/ospf6d.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/isisd.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/ripd.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/ripngd.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/pimd.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/ldpd.conf \
+ && install -m 640 -o frr -g frr /dev/null /etc/frr/nhrpd.conf \
+ && install -m 640 -o frr -g frrvty /dev/null /etc/frr/vtysh.conf \
+ && echo include /usr/local/lib >> /etc/ld.so.conf \
+ && ldconfig \
+ && rm -rf /frr
+
+# Compile the Stateless-patched GoBGP from source.
 WORKDIR /tmp/gobgp
 COPY patch ./
 COPY patches ./patches
@@ -25,9 +90,14 @@ RUN export GOPATH=/go \
  && cd $GOPATH/src/github.com/osrg/gobgp \
  && rm -rf /tmp/gobgp \
  && go mod download \
- && go build -o /gobgp ./cmd/gobgp/ \
- && go build -o /gobgpd ./cmd/gobgpd/ \
+ && go build -o /usr/local/bin/gobgp ./cmd/gobgp/ \
+ && go build -o /usr/local/bin/gobgpd ./cmd/gobgpd/ \
  && rm -rf $GOPATH
 
-COPY ./docker/monitor /
-CMD [ "/monitor" ]
+COPY ./docker/daemons                /etc/frr
+COPY ./docker/frr.conf               /etc/frr
+COPY ./docker/supervisor_tenant.conf /etc/supervisor
+COPY ./docker/supervisor_link.conf   /etc/supervisor
+COPY ./docker/monitor                /usr/local/bin
+
+CMD [ "monitor" ]

--- a/docker/daemons
+++ b/docker/daemons
@@ -1,0 +1,2 @@
+vtysh_enable=no
+zebra_options=" -A 127.0.0.1 -s 90000000"

--- a/docker/frr.conf
+++ b/docker/frr.conf
@@ -1,0 +1,1 @@
+log stdout

--- a/docker/monitor
+++ b/docker/monitor
@@ -1,18 +1,27 @@
-#!/bin/bash
+#!/bin/bash -eu
 
 # Wait for gobgpd to start up and create the unix domain socket for the API.
 # This will be done manually by the orchestrator because it needs to be
 # launched in a separate network namespace.
 echo "Waiting for gobgpd.sock..."
-while [[ ! -S /gobgpd.sock ]]; do sleep 1; done
+while [[ ! -S /gobgpd.sock ]]; do sleep 0.1; done
 
 # Get gobgp's pid so we can watch it and know if it dies.
-GOBGPD_PID=$(ps ax -o pid,cmd | grep gobgpd | grep -v grep | awk '{print $1}')
+GOBGPD_PID=$(ps ax -o pid,comm | grep gobgpd | awk '{print $1}')
 if [[ $? -ne 0 || -z "${GOBGPD_PID}" ]]; then
   echo "Detected gobgpd launch, but couldn't get pid."
   exit 1
 fi
 echo "gobgpd launched, pid=${GOBGPD_PID}"
+
+# Try to get zebra's pid. It may or may not be running, but if it is running
+# then we want to die if it dies.
+ZEBRA_PID=$(ps ax -o pid,comm | grep zebra | awk '{print $1}' || true)
+if [[ -n "${ZEBRA_PID}" ]]; then
+  echo "zebra launched, pid=${ZEBRA_PID}"
+else
+  echo "zebra launch not detected"
+fi
 
 # Launch socat that will listen on TCP and communicate the data that goes over
 # that TCP connection to the gobgpd unix socket.
@@ -47,6 +56,12 @@ while sleep 1; do
     # Unfortunately, can't get the exit code since gobgpd isn't a child of this
     # bash script.
     echo "gobgp died...exiting"
+    exit 1
+  fi
+  if [[ -n "${ZEBRA_PID}" && ! -d "/proc/${ZEBRA_PID}" ]]; then
+    # Unfortunately, can't get the exit code since zebra isn't a child of this
+    # bash script.
+    echo "zebra died...exiting"
     exit 1
   fi
 done

--- a/docker/supervisor_link.conf
+++ b/docker/supervisor_link.conf
@@ -1,0 +1,19 @@
+[supervisord]
+nodaemon=true
+user=root
+
+[program:zebra]
+command=/usr/lib/frr/frrinit.sh start
+autorestart=false
+startsecs=0
+stdout_logfile=/proc/1/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/proc/1/fd/2
+stderr_logfile_maxbytes=0
+
+[program:gobgpd]
+command=/bin/bash -c "until [[ -S /var/opt/frr/zserv.api ]]; do echo 'Waiting for Zebra...' && /bin/sleep 1; done && exec gobgpd -p -l debug --pprof-disable --api-hosts=unix:///gobgpd.sock"
+stdout_logfile=/proc/1/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/proc/1/fd/2
+stderr_logfile_maxbytes=0

--- a/docker/supervisor_tenant.conf
+++ b/docker/supervisor_tenant.conf
@@ -1,0 +1,10 @@
+[supervisord]
+nodaemon=true
+user=root
+
+[program:gobgpd]
+command=gobgpd -p -l debug --pprof-disable --api-hosts=unix:///gobgpd.sock
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0

--- a/test/run-tests
+++ b/test/run-tests
@@ -1,0 +1,96 @@
+#!/bin/bash -eux
+# Runs some simple sanity checks to make sure the gobgp container works like we think it should.
+
+[[ ${EUID} -ne 0 ]] && echo "Must run as root." && exit 1
+
+# Run from the parent directory of this script (the repository root.)
+cd "$(readlink --canonicalize "$(dirname "$0")/..")"
+
+# Make sure things get cleaned up no matter how we exit. Comment out the contents of this function and replace them with
+# "true" if you have a failing test and you don't want cleanup to run and destroy the state.
+cleanup() {
+  docker rm -f "${CONTAINER_ID}" >/dev/null 2>&1 || true
+  ip netns del gobgp_ns || true
+}
+trap cleanup EXIT
+
+# Make sure the gobgp container we want to test has been built from the latest version of the Dockerfile.
+docker build . --file docker/Dockerfile --tag gobgp_test
+
+# The gobgp container is a little weird. We run a monitor script in the primary container namespace, but gobgp/zebra run
+# in another, manually created namespace. Here, the manually created namespace is named "gobgp_ns".
+ip netns add gobgp_ns
+
+########################
+# TENANT VERSION TESTS #
+########################
+
+# Run the "tenant" version of the router (does not run zebra).
+CONTAINER_ID="$(docker run --detach --net none gobgp_test)"
+
+# Launch supervisord in the manually created network namespace, but in all of the other namespaces (pid, mount, user,
+# etc. of the container).
+MONITOR_PID="$(docker inspect --format '{{.State.Pid}}' "${CONTAINER_ID}")"
+nsenter -t "${MONITOR_PID}" -m -u -i -p -r -C --net=/var/run/netns/gobgp_ns /bin/bash -c \
+  "supervisord -c /etc/supervisor/supervisor_tenant.conf </dev/null >/proc/1/fd/1 2>/proc/1/fd/2 &"
+
+# Wait for gobgpd to start up.
+until docker exec "${CONTAINER_ID}" bash -c "[[ -S /gobgpd.sock ]]"; do echo "Waiting for gobgpd startup..."; done
+
+# Run a gobgp command through the unix socket to make sure that works.
+docker exec "${CONTAINER_ID}" gobgp --unix-socket /gobgpd.sock neighbor
+
+# Wait for the monitor script to acknowledge that gobgpd has started. I'm not sure of any non-hacky non-sleep way to do
+# this. The monitor script checks for gobgpd to have started every 0.1 seconds, so waiting a second here is likely
+# plenty of time.
+sleep 1
+
+# Kill the gobgpd process.
+kill -9 "$(ip netns exec gobgp_ns ps -e -o pid,comm | grep gobgpd | awk '{print $1}')"
+
+# Wait up to 3 seconds for the container to die as a result of killing gobgpd.
+MONITOR_DIED=false
+for i in $(seq 1 3); do
+  sleep 1
+  [[ "$(docker inspect --format '{{.State.Status}}' "${CONTAINER_ID}")" == "exited" ]] && MONITOR_DIED=true && break
+done
+[[ "${MONITOR_DIED}" = false ]] && echo "Monitor did not die when gobgpd was killed!" && exit 1
+
+docker rm -f "${CONTAINER_ID}"
+
+######################
+# LINK VERSION TESTS #
+######################
+
+# Run the "link" version of the router.
+CONTAINER_ID="$(docker run --detach --net none gobgp_test)"
+
+# Launch supervisord in the manually created network namespace, but in all of the other namespaces (pid, mount, user,
+# etc. of the container).
+MONITOR_PID="$(docker inspect --format '{{.State.Pid}}' "${CONTAINER_ID}")"
+nsenter -t "${MONITOR_PID}" -m -u -i -p -r -C --net=/var/run/netns/gobgp_ns /bin/bash -c \
+  "supervisord -c /etc/supervisor/supervisor_link.conf </dev/null >/proc/1/fd/1 2>/proc/1/fd/2 &"
+
+# Wait for gobgpd to start up.
+until docker exec "${CONTAINER_ID}" bash -c "[[ -S /gobgpd.sock ]]"; do echo "Waiting for gobgpd startup..."; done
+
+# Run a gobgp command through the unix socket to make sure that works.
+docker exec "${CONTAINER_ID}" gobgp --unix-socket /gobgpd.sock neighbor
+
+# Wait for the monitor script to acknowledge that gobgpd has started. I'm not sure of any non-hacky non-sleep way to do
+# this. The monitor script checks for gobgpd to have started every 0.1 seconds, so waiting a second here is likely
+# plenty of time.
+sleep 1
+
+# Kill the zebra process.
+kill -9 "$(ip netns exec gobgp_ns ps -e -o pid,comm | grep zebra | awk '{print $1}')"
+
+# Wait up to 3 seconds for the container to die as a result of killing zebra.
+MONITOR_DIED=false
+for i in $(seq 1 3); do
+  sleep 1
+  [[ "$(docker inspect --format '{{.State.Status}}' "${CONTAINER_ID}")" == "exited" ]] && MONITOR_DIED=true && break
+done
+[[ "${MONITOR_DIED}" = false ]] && echo "Monitor did not die when zebra was killed!" && exit 1
+
+docker rm -f "${CONTAINER_ID}"


### PR DESCRIPTION
FRR is now necessary in the GoBGP container for EVPN because we need it to install routes in the Linux kernel routing table so that GoBGP can peer with fellow iBGP speakers using learned routes from eBGP. Right now we only want to launch Zebra for the link GoBGP instances, _not_ the tenant GoBGP instances, although we may want to launch Zebra on those in the future.

To add FRR we moved to a new version of `stateless-apt` because we require new packages in order to build FRR. We then build FRR from source in the Dockerfile and copy over the config files necessary to run Zebra. Additionally, moved `/monitor`, `/gobgp`, and `/gobgpd` to `/usr/local/bin` since that is a better location for them. Two new `supervisord` config files were added:

* `supervisor_tenant.conf` -- Just runs GoBGP.
* `supervisor_link.conf` -- Runs Zebra first and then GoBGP.

Which file to use will be selected by the orchestrator code at runtime.

Finally, added some simple tests to make sure the monitor script works, and the unix socket patch to GoBGP works. This is a minimal test infrastructure. We can add additional self-tests in this repo to make sure that the `SetConfig` API works, and that routers can peer with each other and that Zebra actually adds routes to the route table. 

### Related PRs

* BeStateless/stateless-apt#14
* BeStateless/gobgp#4
* BeStateless/platform-config#48
* BeStateless/stateless-nf#333
* BeStateless/stateless-orchestrator#241
* BeStateless/stateless-kafka-container#1
