### PR TITLE
NF-623 - Fix issue generating GRPC.

### DIFF
--- a/docker/Dockerfile.genproto
+++ b/docker/Dockerfile.genproto
@@ -1,4 +1,4 @@
-FROM statelesstestregistry.azurecr.io/stateless/base:8 as build
+FROM statelesstestregistry.azurecr.io/stateless/base:9 as build
 
 # Install build dependencies.
 RUN apt-get update \
@@ -27,6 +27,10 @@ RUN export GOPATH=/go \
  && mv gobgp $GOPATH/src/github.com/osrg \
  && rm -rf /tmp/gobgp \
  && cd $GOPATH/src/github.com/osrg/gobgp \
+    # This is goofy, but we need to generate the GRPC with the version that GoBGP uses, but when we compile GoBGP we
+    # need to use a newer version to fix a bug in GRPC. No matter what we have to do something weird. When we generate
+    # the GRPC with the newer version it generates a bunch of garbage and makes the diffs very annoying.
+ && sed -i 's|google.golang.org/grpc v1.24.0|google.golang.org/grpc v1.5.1|' go.mod \
  && go mod download \
  && go install github.com/golang/protobuf/protoc-gen-go \
  && export GOPROTO="$(GO111MODULE=on go list -f '{{ .Dir }}' -m github.com/golang/protobuf)" \

--- a/patches/monitor-table-multi.patch
+++ b/patches/monitor-table-multi.patch
@@ -11,7 +11,7 @@ From: Aaron Jones <aaron@vexing.codes>
  4 files changed, 24 insertions(+), 12 deletions(-)
 
 diff --git a/api/gobgp.proto b/api/gobgp.proto
-index 329b6930..0eac96e9 100644
+index d9a123ba..10f6ea66 100644
 --- a/api/gobgp.proto
 +++ b/api/gobgp.proto
 @@ -263,7 +263,7 @@ message MonitorTableRequest {

--- a/patches/set-config-api.patch
+++ b/patches/set-config-api.patch
@@ -6,15 +6,15 @@ This API allows you to set the configuration of the GoBGP router
 after it's been launched and get an error if the configuraiton
 failed to be applied.
 ---
- api/gobgp.proto                |   15 ++++++
+ api/gobgp.proto                |   16 ++++++
  cmd/gobgpd/main.go             |  101 ++++++++++++++++++++++++----------------
  internal/pkg/config/default.go |    4 ++
  pkg/server/grpc_server.go      |   37 ++++++++++++++-
  pkg/server/server.go           |   24 +++++++---
- 5 files changed, 132 insertions(+), 49 deletions(-)
+ 5 files changed, 133 insertions(+), 49 deletions(-)
 
 diff --git a/api/gobgp.proto b/api/gobgp.proto
-index b61b4759..329b6930 100644
+index b61b4759..d9a123ba 100644
 --- a/api/gobgp.proto
 +++ b/api/gobgp.proto
 @@ -95,6 +95,8 @@ service GobgpApi {
@@ -26,7 +26,7 @@ index b61b4759..329b6930 100644
  }
  
  message StartBgpRequest {
-@@ -1191,3 +1193,16 @@ message Rpki {
+@@ -1191,3 +1193,17 @@ message Rpki {
    RPKIConf conf = 1;
    RPKIState state = 2;
  }
@@ -43,6 +43,7 @@ index b61b4759..329b6930 100644
 +}
 +
 +message SetConfigResponse{
++}
 diff --git a/cmd/gobgpd/main.go b/cmd/gobgpd/main.go
 index 48eb43ac..9e4a1b7a 100644
 --- a/cmd/gobgpd/main.go


### PR DESCRIPTION
There were two problems.

First, generating the GRPC files using GRPC `v1.24.0` put a lot of extra garbage into the generated Go files, making the diffs much larger. However, we need `v1.24.0` to get around a bug in GRPC allowing Unix sockets. So, when generating the GRPC we switch back to `v1.5.1`, but still compile using `v1.24.0`. This seems to work fine, but may not work fine permanently.

The second problem was that the GRPC file was missing the final closing brace. I'm not certain how this slipped in, but it was easy enough to fix.