### PR TITLE
NF-994: Updates changes to reflect newer GoBGP repo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
       automake \
       build-essential \
       ca-certificates \
+      curl \
       golang \
       libreadline-dev \
       texinfo \
@@ -26,6 +27,7 @@ RUN apt-get update \
       socat \
       stgit \
       supervisor \
+      unzip \
  && rm -rf /var/lib/apt/lists/*
 
 
@@ -75,12 +77,18 @@ RUN addgroup --system --gid 92 frr \
  && ldconfig \
  && rm -rf /frr
 
+RUN export PROTOC_ZIP=protoc-3.7.1-linux-x86_64.zip \
+ && curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/$PROTOC_ZIP \
+ && unzip -o $PROTOC_ZIP -d /usr/local bin/protoc \
+ && unzip -o $PROTOC_ZIP -d /usr/local 'include/*' \
+ && rm -f $PROTOC_ZIP
+
 # Compile the Stateless-patched GoBGP from source.
 WORKDIR /tmp/gobgp
 COPY patch ./
 COPY patches ./patches
 RUN export GOPATH=/go \
- && export PATH="$GOPATH/bin:/usr/local/go/bin:$PATH" \
+ && export PATH="$GOPATH/bin:/usr/local/bin/protoc:/usr/local/go/bin:$PATH" \
  && export GO111MODULE=on \
  && ./patch \
  && mkdir -p "$GOPATH/src" "$GOPATH/bin" \
@@ -89,6 +97,7 @@ RUN export GOPATH=/go \
  && mv gobgp $GOPATH/src/github.com/osrg \
  && cd $GOPATH/src/github.com/osrg/gobgp \
  && rm -rf /tmp/gobgp \
+ && ./tools/grpc/genproto.sh \
  && go mod download \
  && go build -o /usr/local/bin/gobgp ./cmd/gobgp/ \
  && go build -o /usr/local/bin/gobgpd ./cmd/gobgpd/ \

--- a/patches/monitor-table-multi.patch
+++ b/patches/monitor-table-multi.patch
@@ -11,7 +11,7 @@ From: Aaron Jones <aaron@vexing.codes>
  4 files changed, 24 insertions(+), 12 deletions(-)
 
 diff --git a/api/gobgp.proto b/api/gobgp.proto
-index d9a123ba..10f6ea66 100644
+index d49dd652..9dfbb071 100644
 --- a/api/gobgp.proto
 +++ b/api/gobgp.proto
 @@ -263,7 +263,7 @@ message MonitorTableRequest {
@@ -46,7 +46,7 @@ index bc31bde9..865bd693 100644
  		}
  	}
 diff --git a/pkg/server/grpc_server.go b/pkg/server/grpc_server.go
-index 83449cee..6d00c176 100644
+index c8fb222b..efae6c12 100644
 --- a/pkg/server/grpc_server.go
 +++ b/pkg/server/grpc_server.go
 @@ -205,9 +205,9 @@ func (s *server) ListPath(r *api.ListPathRequest, stream api.GobgpApi_ListPathSe
@@ -62,10 +62,10 @@ index 83449cee..6d00c176 100644
  			cancel()
  			return
 diff --git a/pkg/server/server.go b/pkg/server/server.go
-index 580f9a50..a3b64942 100644
+index 1df3a287..adbcc8d1 100644
 --- a/pkg/server/server.go
 +++ b/pkg/server/server.go
-@@ -3664,7 +3664,7 @@ func (s *BgpServer) ResetRpki(ctx context.Context, r *api.ResetRpkiRequest) erro
+@@ -3692,7 +3692,7 @@ func (s *BgpServer) ResetRpki(ctx context.Context, r *api.ResetRpkiRequest) erro
  	}, false)
  }
  
@@ -74,7 +74,7 @@ index 580f9a50..a3b64942 100644
  	if r == nil {
  		return fmt.Errorf("nil request")
  	}
-@@ -3712,15 +3712,23 @@ func (s *BgpServer) MonitorTable(ctx context.Context, r *api.MonitorTableRequest
+@@ -3740,15 +3740,23 @@ func (s *BgpServer) MonitorTable(ctx context.Context, r *api.MonitorTableRequest
  				case *watchEventUpdate:
  					pl = msg.PathList
  				}

--- a/patches/series
+++ b/patches/series
@@ -1,5 +1,4 @@
-# This series applies on GIT commit v2.9.0
+# This series applies on GIT commit 8cadc751ca6cccbf2b8edbab6b11c01b347418eb
 unix-socket.patch
 set-config-api.patch
 monitor-table-multi.patch
-generated-grpc.patch

--- a/patches/set-config-api.patch
+++ b/patches/set-config-api.patch
@@ -10,11 +10,11 @@ failed to be applied.
  cmd/gobgpd/main.go             |  101 ++++++++++++++++++++++++----------------
  internal/pkg/config/default.go |    4 ++
  pkg/server/grpc_server.go      |   37 ++++++++++++++-
- pkg/server/server.go           |   24 +++++++---
- 5 files changed, 133 insertions(+), 49 deletions(-)
+ pkg/server/server.go           |   23 +++++++--
+ 5 files changed, 133 insertions(+), 48 deletions(-)
 
 diff --git a/api/gobgp.proto b/api/gobgp.proto
-index b61b4759..d9a123ba 100644
+index 3ed531a9..d49dd652 100644
 --- a/api/gobgp.proto
 +++ b/api/gobgp.proto
 @@ -95,6 +95,8 @@ service GobgpApi {
@@ -26,7 +26,7 @@ index b61b4759..d9a123ba 100644
  }
  
  message StartBgpRequest {
-@@ -1191,3 +1193,17 @@ message Rpki {
+@@ -1192,3 +1194,17 @@ message Rpki {
    RPKIConf conf = 1;
    RPKIState state = 2;
  }
@@ -183,7 +183,7 @@ index 48eb43ac..9e4a1b7a 100644
  	}
  }
 diff --git a/internal/pkg/config/default.go b/internal/pkg/config/default.go
-index c86ada57..9d52481d 100644
+index 7727bf78..9433f4a0 100644
 --- a/internal/pkg/config/default.go
 +++ b/internal/pkg/config/default.go
 @@ -340,6 +340,10 @@ func setDefaultPolicyConfigValuesWithViper(v *viper.Viper, p *PolicyDefinition)
@@ -198,7 +198,7 @@ index c86ada57..9d52481d 100644
  	if v == nil {
  		v = viper.New()
 diff --git a/pkg/server/grpc_server.go b/pkg/server/grpc_server.go
-index ebbe1175..83449cee 100644
+index 799167cf..c8fb222b 100644
 --- a/pkg/server/grpc_server.go
 +++ b/pkg/server/grpc_server.go
 @@ -34,6 +34,7 @@ import (
@@ -227,7 +227,7 @@ index ebbe1175..83449cee 100644
  	}
  	api.RegisterGobgpApiServer(g, s)
  	return s
-@@ -1769,3 +1772,35 @@ func (s *server) StopBgp(ctx context.Context, r *api.StopBgpRequest) (*empty.Emp
+@@ -1770,3 +1773,35 @@ func (s *server) StopBgp(ctx context.Context, r *api.StopBgpRequest) (*empty.Emp
  func (s *server) GetTable(ctx context.Context, r *api.GetTableRequest) (*api.GetTableResponse, error) {
  	return s.bgpServer.GetTable(ctx, r)
  }
@@ -264,10 +264,10 @@ index ebbe1175..83449cee 100644
 +	return &api.SetConfigResponse{}, nil
 +}
 diff --git a/pkg/server/server.go b/pkg/server/server.go
-index d6c54e10..580f9a50 100644
+index 2ee49ec8..1df3a287 100644
 --- a/pkg/server/server.go
 +++ b/pkg/server/server.go
-@@ -137,12 +137,7 @@ type BgpServer struct {
+@@ -138,11 +138,7 @@ type BgpServer struct {
  	uuidMap      map[string]uuid.UUID
  }
  
@@ -276,12 +276,11 @@ index d6c54e10..580f9a50 100644
 -	for _, o := range opt {
 -		o(&opts)
 -	}
--
 +func NewBgpServer() *BgpServer {
- 	roaManager, _ := newROAManager(0)
+ 	roaTable := table.NewROATable()
  	s := &BgpServer{
  		neighborMap:  make(map[string]*peer),
-@@ -155,9 +150,24 @@ func NewBgpServer(opt ...ServerOption) *BgpServer {
+@@ -156,9 +152,24 @@ func NewBgpServer(opt ...ServerOption) *BgpServer {
  	}
  	s.bmpManager = newBmpClientManager(s)
  	s.mrtManager = newMrtManager(s)

--- a/patches/unix-socket.patch
+++ b/patches/unix-socket.patch
@@ -53,20 +53,20 @@ index 539ae2ed..3490bcb3 100644
  	rootCmd.PersistentFlags().IntVarP(&globalOpts.Port, "port", "p", 50051, "port")
  	rootCmd.PersistentFlags().BoolVarP(&globalOpts.Json, "json", "j", false, "use json format to output format")
 diff --git a/go.mod b/go.mod
-index 928dc102..bb773464 100644
+index f0c93e6f..b5512d0d 100644
 --- a/go.mod
 +++ b/go.mod
-@@ -35,7 +35,7 @@ require (
- 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
- 	golang.org/x/sys v0.0.0-20190405154228-4b34438f7a67 // indirect
+@@ -33,7 +33,7 @@ require (
+ 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
+ 	golang.org/x/tools v0.0.0-20191026034945-b2104f82a97d // indirect
  	google.golang.org/genproto v0.0.0-20170731182057-09f6ed296fc6 // indirect
 -	google.golang.org/grpc v1.5.1
 +	google.golang.org/grpc v1.24.0
- 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
  	gopkg.in/yaml.v2 v2.0.0-20170721122051-25c4ec802a7d // indirect
+ 	honnef.co/go/tools v0.0.0-20191022112108-ee025456fe28 // indirect
  )
 diff --git a/pkg/server/grpc_server.go b/pkg/server/grpc_server.go
-index 3c7527b2..ebbe1175 100644
+index 69af445c..799167cf 100644
 --- a/pkg/server/grpc_server.go
 +++ b/pkg/server/grpc_server.go
 @@ -65,7 +65,20 @@ func (s *server) serve() error {


### PR DESCRIPTION
Also replaces a patch with a cleaner build step to "build" proto.go files from the protobuf, as this makes it easier to pull in protobuf changes from osrc source and modify with any of our patches.